### PR TITLE
Fixed flags that were missing on usage instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ It also has options to find XSS and open redirects.
 If you don't have burpsuite professional, you can use [ssrftest.com](https://www.ssrftest.com) as your server.
 
 ### Requirements
-Since this uses GAU, FFUF, qsreplace and OpenRedirex, you need GO and python 3.7+. You need not have the tools installed, as the script **setup.sh** would install everything.
+Since this uses GAU, FFUF, qsreplace and OpenRedirex, you need GO and python 3.7+. You need not have the tools installed, as the script **setup.sh** will install everything.
 You just need to install python and GO.
 Even if you have the tools installed I would highly recommend you to install them again so that there no conflicts while setting the paths.
 
@@ -56,7 +56,7 @@ qsreplace(){
 ```
 chmod +x setup.sh
 ./setup.sh (preferably yes for all ---> **highly recommended**)
-./ssrfire.sh domain.com yourserver.com
+./ssrfire.sh -d domain.com -s yourserver.com
 ```
 ### Finding SSRF
 Now, gau gets into action by fetching all the URLs of the domain. This may take a lot of time.
@@ -67,19 +67,19 @@ But if you want to test the URLs fetched till now, quit the process.
 Copy the raw_urls.txt inside of output/domain.com and place it outside the domain.com folder
 Now run
 ```
-./ssrfire.sh domain.com yourserver.com /path/to/copied_raw_urls.txt
+./ssrfire.sh -d domain.com -s yourserver.com -f /path/to/copied_raw_urls.txt
 ```
 Select yes when asked whether to delete the existing folder.
 
 This will skip the process of GAU fetching URLs.
 
-Now the all the URLs with the parameters will be filtered and yourserver.com will be placed into their parameter values.(final_urls.txt)
+Now all the URLs with parameters will be filtered and yourserver.com will be placed into their parameter values.(final_urls.txt)
 
-The next step is to fire request to all the final URLs.
+The next step is to fire requests to all the final URLs.
 
 ### Finding XSS
 
-**Warning: This generates a lot of traffic. Do not use this against the sites which you are not authorised to test**
+**Warning: This generates a lot of traffic. Do not use this against sites which you are not authorized to test**
 
 This tests all the URLs fetched, and based on how the input is reflected in the response, it adds that particular URL to the output/domain.com/xss-suspects.txt **(This may contain false positives)**
 


### PR DESCRIPTION
In lines with usage instructions the flags where missing, e.g ./ssrfire.sh domain.com instead of /ssrfire.sh -d domain.com, so I added them to avoid confusion. Since I was at it I also fixed a few grammatical errors I spotted. Awesome tool, I was looking for something lke this :)

This is my first pull request, my sincere apologies if I am doing something wrong.